### PR TITLE
include fstream in RecSplit

### DIFF
--- a/sux/function/RecSplit.hpp
+++ b/sux/function/RecSplit.hpp
@@ -38,6 +38,7 @@
 #include <cmath>
 #include <string>
 #include <vector>
+#include <fstream>
 
 namespace sux::function {
 


### PR DESCRIPTION
Because fstream is not included RecSplit, this does not compile:
```
#include "sux/function/RecSplit.hpp"

int main()  {
}
```