### PR TITLE
Actually return bits in getBits method

### DIFF
--- a/sux/function/RiceBitVector.hpp
+++ b/sux/function/RiceBitVector.hpp
@@ -117,7 +117,7 @@ template <util::AllocType AT = util::AllocType::MALLOC> class RiceBitVector {
 	RiceBitVector() {}
 	RiceBitVector(util::Vector<uint64_t, AT> data) : data(std::move(data)) {}
 
-	size_t getBits() const { return data.size() * sizeof(uint64_t); }
+	size_t getBits() const { return data.size() * sizeof(uint64_t) * 8; }
 
 	class Reader {
 		size_t curr_fixed_offset = 0;


### PR DESCRIPTION
`RiceBitVector.Builder.getBits` returns the number of bits used by the data structure but `RiceBitVector.getBits` returns the number of *bytes* used by the data structure. Fixed `RiceBitVector.getBits`, so it actually returns bits.