### PR TITLE
Add fallthrough attribute to SpookyHash::Short128 cases without break

### DIFF
--- a/sux/support/SpookyV2.hpp
+++ b/sux/support/SpookyV2.hpp
@@ -369,36 +369,47 @@ class SpookyHash {
 		switch (remainder) {
 		case 15:
 			d += ((uint64_t)u.p8[14]) << 48;
+			[[fallthrough]];
 		case 14:
 			d += ((uint64_t)u.p8[13]) << 40;
+			[[fallthrough]];
 		case 13:
 			d += ((uint64_t)u.p8[12]) << 32;
+			[[fallthrough]];
 		case 12:
 			d += u.p32[2];
 			c += u.p64[0];
 			break;
 		case 11:
 			d += ((uint64_t)u.p8[10]) << 16;
+			[[fallthrough]];
 		case 10:
 			d += ((uint64_t)u.p8[9]) << 8;
+			[[fallthrough]];
 		case 9:
 			d += (uint64_t)u.p8[8];
+			[[fallthrough]];
 		case 8:
 			c += u.p64[0];
 			break;
 		case 7:
 			c += ((uint64_t)u.p8[6]) << 48;
+			[[fallthrough]];
 		case 6:
 			c += ((uint64_t)u.p8[5]) << 40;
+			[[fallthrough]];
 		case 5:
 			c += ((uint64_t)u.p8[4]) << 32;
+			[[fallthrough]];
 		case 4:
 			c += u.p32[0];
 			break;
 		case 3:
 			c += ((uint64_t)u.p8[2]) << 16;
+			[[fallthrough]];
 		case 2:
 			c += ((uint64_t)u.p8[1]) << 8;
+			[[fallthrough]];
 		case 1:
 			c += (uint64_t)u.p8[0];
 			break;


### PR DESCRIPTION
Adding the [fallthrough attribute](https://en.cppreference.com/w/cpp/language/attributes/fallthrough) attribute to avoid annoying compile warnings (becoming errors if compiling with the `-Werror` option):

```
In file included from ./sux/function/RecSplit.hpp:31,
                 from test/function/recsplit.hpp:8,
                 from test/function/test.cpp:8:
./sux/function/../support/SpookyV2.hpp: In static member function ‘static void SpookyHash::Short128(const void*, size_t, uint64_t*, uint64_t*)’:
./sux/function/../support/SpookyV2.hpp:371:27: warning: this statement may fall through [-Wimplicit-fallthrough=]
  371 |                         d += ((uint64_t)u.p8[14]) << 48;
      |                         ~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./sux/function/../support/SpookyV2.hpp:372:17: note: here
  372 |                 case 14:
      |                 ^~~~
./sux/function/../support/SpookyV2.hpp:373:27: warning: this statement may fall through [-Wimplicit-fallthrough=]
  373 |                         d += ((uint64_t)u.p8[13]) << 40;
      |                         ~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./sux/function/../support/SpookyV2.hpp:374:17: note: here
  374 |                 case 13:
      |                 ^~~~
./sux/function/../support/SpookyV2.hpp:375:27: warning: this statement may fall through [-Wimplicit-fallthrough=]
  375 |                         d += ((uint64_t)u.p8[12]) << 32;
      |                         ~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./sux/function/../support/SpookyV2.hpp:376:17: note: here
  376 |                 case 12:
      |                 ^~~~
./sux/function/../support/SpookyV2.hpp:381:27: warning: this statement may fall through [-Wimplicit-fallthrough=]
  381 |                         d += ((uint64_t)u.p8[10]) << 16;
      |                         ~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./sux/function/../support/SpookyV2.hpp:382:17: note: here
  382 |                 case 10:
      |                 ^~~~
./sux/function/../support/SpookyV2.hpp:383:27: warning: this statement may fall through [-Wimplicit-fallthrough=]
  383 |                         d += ((uint64_t)u.p8[9]) << 8;
      |                         ~~^~~~~~~~~~~~~~~~~~~~~~~~~~~
./sux/function/../support/SpookyV2.hpp:384:17: note: here
  384 |                 case 9:
      |                 ^~~~
./sux/function/../support/SpookyV2.hpp:385:27: warning: this statement may fall through [-Wimplicit-fallthrough=]
  385 |                         d += (uint64_t)u.p8[8];
      |                         ~~^~~~~~~~~~~~~~~~~~~~
./sux/function/../support/SpookyV2.hpp:386:17: note: here
  386 |                 case 8:
      |                 ^~~~
./sux/function/../support/SpookyV2.hpp:390:27: warning: this statement may fall through [-Wimplicit-fallthrough=]
  390 |                         c += ((uint64_t)u.p8[6]) << 48;
      |                         ~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
./sux/function/../support/SpookyV2.hpp:391:17: note: here
  391 |                 case 6:
      |                 ^~~~
./sux/function/../support/SpookyV2.hpp:392:27: warning: this statement may fall through [-Wimplicit-fallthrough=]
  392 |                         c += ((uint64_t)u.p8[5]) << 40;
      |                         ~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
./sux/function/../support/SpookyV2.hpp:393:17: note: here
  393 |                 case 5:
      |                 ^~~~
./sux/function/../support/SpookyV2.hpp:394:27: warning: this statement may fall through [-Wimplicit-fallthrough=]
  394 |                         c += ((uint64_t)u.p8[4]) << 32;
      |                         ~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
./sux/function/../support/SpookyV2.hpp:395:17: note: here
  395 |                 case 4:
      |                 ^~~~
./sux/function/../support/SpookyV2.hpp:399:27: warning: this statement may fall through [-Wimplicit-fallthrough=]
  399 |                         c += ((uint64_t)u.p8[2]) << 16;
      |                         ~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
./sux/function/../support/SpookyV2.hpp:400:17: note: here
  400 |                 case 2:
      |                 ^~~~
./sux/function/../support/SpookyV2.hpp:401:27: warning: this statement may fall through [-Wimplicit-fallthrough=]
  401 |                         c += ((uint64_t)u.p8[1]) << 8;
      |                         ~~^~~~~~~~~~~~~~~~~~~~~~~~~~~
./sux/function/../support/SpookyV2.hpp:402:17: note: here
  402 |                 case 1:
      |                 ^~~~
```